### PR TITLE
add makeInstanceAndDefault variant with default adaptor name

### DIFF
--- a/Test/CheckTypes.hs
+++ b/Test/CheckTypes.hs
@@ -4,7 +4,9 @@ import Data.Profunctor.Product (ProductProfunctor)
 import Data.Profunctor.Product.Default (Default, def)
 
 import Definitions (Data2, Data3, Record2, Record3,
-                    pData2, pData3, pRecord2, pRecord3)
+                    RecordDefaultName,
+                    pData2, pData3, pRecord2, pRecord3,
+                    pRecordDefaultName)
 
 -- The test suite checks that the TH derived adaptor is of the correct
 -- type and that the typeclass instance has been generated.  We don't
@@ -45,3 +47,6 @@ instanceRecord3 :: (ProductProfunctor p,
                   Default p a a', Default p b b', Default p c c')
                  => p (Record3 a b c) (Record3 a' b' c')
 instanceRecord3 = def
+
+defaultNameGenerated :: ProductProfunctor p => RecordDefaultName (p x x') (p y y') -> p (RecordDefaultName x y) (RecordDefaultName x' y')
+defaultNameGenerated = pRecordDefaultName

--- a/Test/Definitions.hs
+++ b/Test/Definitions.hs
@@ -8,7 +8,7 @@ module Definitions where
 -- because we want to ensure that no external names are required to be
 -- imported.
 
-import Data.Profunctor.Product.TH (makeAdaptorAndInstance)
+import Data.Profunctor.Product.TH (makeAdaptorAndInstance, makeAdaptorAndInstance')
 
 data Data2 a b = Data2 a b
 data Data3 a b c = Data3 a b c
@@ -16,7 +16,10 @@ data Data3 a b c = Data3 a b c
 data Record2 a b = Record2 { a2 :: a, b2 :: b }
 data Record3 a b c = Record3 { a3 :: a, b3 :: b, c3 :: c }
 
+data RecordDefaultName x y = RecordDefaultName { x :: x, y :: y }
+
 $(makeAdaptorAndInstance "pData2" ''Data2)
 $(makeAdaptorAndInstance "pData3" ''Data3)
 $(makeAdaptorAndInstance "pRecord2" ''Record2)
 $(makeAdaptorAndInstance "pRecord3" ''Record3)
+makeAdaptorAndInstance' ''RecordDefaultName


### PR DESCRIPTION
A version of `makeInstanceAndDefault` that derives the name from the constructor by prepending a `p`.

Therefore:

    data Orders' a b = Orders a b
    makeInstanceAndDefault' ''Orders'

will generate adaptor with name `pOrders`.