### PR TITLE
Also add Default instances for Tagged.

### DIFF
--- a/Data/Profunctor/Product/Default.hs
+++ b/Data/Profunctor/Product/Default.hs
@@ -5,9 +5,10 @@ module Data.Profunctor.Product.Default where
 
 import Control.Applicative (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
-import Data.Profunctor (Profunctor (dimap))
+import Data.Profunctor (Profunctor, dimap)
 -- TODO: vv this imports a lot of names.  Should we list them all?
 import Data.Profunctor.Product
+import Data.Tagged (Tagged (Tagged))
 
 class Default p a b where
   -- Would rather call it "default", but that's a keyword
@@ -277,3 +278,7 @@ instance (Profunctor p, Default p a b) => Default p (Identity a) (Identity b)
 instance (Profunctor p, Default p a b) => Default p (Const a c) (Const b c')
   where
     def = dimap (\(Const a) -> a) Const def
+
+instance (Profunctor p, Default p a b) => Default p (Tagged s a) (Tagged s' b)
+  where
+    def = dimap (\(Tagged a) -> a) Tagged def

--- a/product-profunctors.cabal
+++ b/product-profunctors.cabal
@@ -19,6 +19,7 @@ library
   build-depends:   base >= 4.5 && < 5
                  , profunctors >= 4.0 && < 5.3
                  , contravariant >= 0.4 && < 1.5
+                 , tagged >= 0.0 && < 1
                  , template-haskell
   exposed-modules: Data.Profunctor.Product,
                    Data.Profunctor.Product.Default,


### PR DESCRIPTION
Let's say you have a table called `foo`, and it has an `id` column of type `int` (`PGInt4`). Let's say you have another table called `bar`, and you want each `bar` to be associated with a `foo`. So in your `bar` table you have a column `bar_id` of type `int` (`PGInt4`), which is a foreign key pointing to the `id` column of the `foo` table.

Now let's say you have a Haskell function that uses `Opaleye` to get all the `bar`s associated with a given `foo`:

    getFooBars :: QueryArr Foo Bar
    getFooBars = proc foo -> do
        bar <- queryTable barTable -< ()
        restrict -< bar ^. fooId .== foo ^. id_
        returnA -< bar

(Let's say `fooId` and `id_` are lenses that get the `foo_id` field and `id` field of `Bar` and `Foo` respectively.)

If you did this naively, `bar ^. fooId` and `foo ^. id_` would both have type `Column PGInt4`. Which works, of course. But there's nothing stopping you accidentally typing `bar ^. barId .== foo ^. id_` by accident, and having it also type check (assuming the `bar` table also has a `barId` field of type `int` (`PGInt4`)).

We can solve this by "tagging" the type of the `id` column (on the Haskell side of things) with a `Symbol` referring to the name of the table which the to which a particular `id` column refers.

    type ID a = Tagged a PGInt4

What I want to do is to make `bar ^. fooId` have the type `Column (ID "foo")` and `bar ^. barId` have the type `Column (ID "bar")`.

In order to make all of that work seamlessly, I need these `Default` instances for `Tagged`, and I also need `instance QueryRunnerColumnDefault a b => QueryRunnerColumnDefault (Tagged s a) (Tagged s' b)`, which I'll submit as a separate patch to your `haskell-opaleye` project.

What I want to do is to make `bar ^. fooId` have the type `Column (ID "foo")` and `bar ^. barId` have the type `Column (ID "bar")` (where `ID` is a type synonym in terms of `Tagged` as above). This prevents these types of programming errors.

In order to do that, I need these `Default` instances for `Tagged`.

(I also need `instance QueryRunnerColumnDefault a b => QueryRunnerColumnDefault (Tagged s a) (Tagged s' b)`, which I'll submit as a separate patch to your `haskell-opaleye` project.)