### PR TITLE
Enabled PolyKinds (with CPP guard) in Data.Profunctor.Product.Default

### DIFF
--- a/Data/Profunctor/Product/Default.hs
+++ b/Data/Profunctor/Product/Default.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances,
-             FlexibleContexts #-}
+             FlexibleContexts, PolyKinds #-}
 
 module Data.Profunctor.Product.Default where
 


### PR DESCRIPTION
The Default instances for `Const` and `Tagged` were being restricted to `Const :: * -> * -> *` and `Tagged :: * -> * -> *` before this change. Now they work for all `Const :: * -> k -> *` and `Tagged :: k -> * -> *`.