### PR TITLE
Added pass-through Default instances for covariant-only and contravariant-only profunctors

### DIFF
--- a/Data/Profunctor/Product/Default.hs
+++ b/Data/Profunctor/Product/Default.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances,
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, ScopedTypeVariables,
              FlexibleContexts, PolyKinds, TemplateHaskell #-}
 
 module Data.Profunctor.Product.Default
@@ -9,13 +9,15 @@ module Data.Profunctor.Product.Default
 
 import Control.Applicative (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
-import Data.Profunctor (Profunctor, dimap, rmap)
+import Data.Profunctor (Profunctor, dimap, lmap, rmap)
 -- TODO: vv this imports a lot of names.  Should we list them all?
 import Data.Profunctor.Product
 import Data.Tagged (Tagged (Tagged))
+import Data.Void (Void, absurd)
 
 import Data.Profunctor.Product.Default.Class
 import Data.Profunctor.Product.Tuples.TH ( mkDefaultNs, mkDefaultCovariantNs
+                                         , mkDefaultContravariantNs
                                          , maxTupleSize
                                          )
 
@@ -34,17 +36,24 @@ instance (Profunctor p, Default p a b) => Default p (Tagged s a) (Tagged s' b)
   where
     def = dimap (\(Tagged a) -> a) Tagged def
 
-instance (Profunctor p, Default p () a) => Default p () (Identity a)
-  where
+instance (Profunctor p, Default p () a) => Default p () (Identity a) where
     def = rmap Identity def
 
-instance (Profunctor p, Default p () a) => Default p () (Const a c)
-  where
+instance (Profunctor p, Default p () a) => Default p () (Const a c) where
     def = rmap Const def
 
-instance (Profunctor p, Default p () a) => Default p () (Tagged s a)
-  where
+instance (Profunctor p, Default p () a) => Default p () (Tagged s a) where
     def = rmap Tagged def
+
+instance (Profunctor p, Default p a Void) => Default p (Identity a) Void where
+    def = lmap (\(Identity a) -> a) def
+
+instance (Profunctor p, Default p a Void) => Default p (Const a c) Void where
+    def = lmap (\(Const a) -> a) def
+
+instance (Profunctor p, Default p a Void) => Default p (Tagged s a) Void where
+    def = lmap (\(Tagged a) -> a) def
 
 mkDefaultNs (0:[2..maxTupleSize])
 mkDefaultCovariantNs ([2..maxTupleSize])
+mkDefaultContravariantNs ([2..maxTupleSize])

--- a/Data/Profunctor/Product/Default.hs
+++ b/Data/Profunctor/Product/Default.hs
@@ -9,13 +9,15 @@ module Data.Profunctor.Product.Default
 
 import Control.Applicative (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
-import Data.Profunctor (Profunctor, dimap)
+import Data.Profunctor (Profunctor, dimap, rmap)
 -- TODO: vv this imports a lot of names.  Should we list them all?
 import Data.Profunctor.Product
 import Data.Tagged (Tagged (Tagged))
 
 import Data.Profunctor.Product.Default.Class
-import Data.Profunctor.Product.Tuples.TH (mkDefaultNs, maxTupleSize)
+import Data.Profunctor.Product.Tuples.TH ( mkDefaultNs, mkDefaultCovariantNs
+                                         , maxTupleSize
+                                         )
 
 cdef :: Default (PPOfContravariant u) a a => u a
 cdef = unPPOfContravariant def
@@ -32,4 +34,17 @@ instance (Profunctor p, Default p a b) => Default p (Tagged s a) (Tagged s' b)
   where
     def = dimap (\(Tagged a) -> a) Tagged def
 
+instance (Profunctor p, Default p () a) => Default p () (Identity a)
+  where
+    def = rmap Identity def
+
+instance (Profunctor p, Default p () a) => Default p () (Const a c)
+  where
+    def = rmap Const def
+
+instance (Profunctor p, Default p () a) => Default p () (Tagged s a)
+  where
+    def = rmap Tagged def
+
 mkDefaultNs (0:[2..maxTupleSize])
+mkDefaultCovariantNs ([2..maxTupleSize])

--- a/product-profunctors.cabal
+++ b/product-profunctors.cabal
@@ -37,7 +37,7 @@ library
   ghc-options:     -Wall
 
   if impl(ghc < 7.10)
-    build-depends: transformers >= 0.2 && < 0.6
+    build-depends: transformers >= 0.2 && < 0.6, void >= 0.4 && < 0.8
 
 test-suite test
   default-language: Haskell2010


### PR DESCRIPTION
Not sure if I'm using the right terminology to describe this, but basically if you have a "constant" profunctor `p () a` (i.e., it doesn't use its left argument) that has a `Default` instance, then you should also be able to get `p () (Identity a)` and so on, and, if `p` is an instance of `ProductProfunctor`, then `p () (a, b)`, etc. This pull request implements that.