### PR TITLE
Increase lower bound on profunctors

### DIFF
--- a/product-profunctors.cabal
+++ b/product-profunctors.cabal
@@ -20,7 +20,7 @@ source-repository head
 library
   default-language: Haskell2010
   build-depends:   base >= 4.5 && < 5
-                 , profunctors >= 4.0 && < 5.3
+                 , profunctors   >= 5   && < 5.3
                  , bifunctors    >= 5.4 && < 6.0
                  , contravariant >= 0.4 && < 1.5
                  , tagged >= 0.0 && < 1


### PR DESCRIPTION
`profunctors` added `Star` in version `5`. I'm assuming this not being an issue means noone's using a `profunctors` version that old.

I found this problem when I tried to build with GHC 7.8.4 with a build plan generated by stack and it somehow picked the oldest `profunctors` it could.