### PR TITLE
Fix CI badge URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
     - uses: tomjaguarpaw/neil@tag-ac7e72e
       with:
         github-user: tomjaguarpaw
-        branch: tag-ac7e72e
+        branch: tag-4459934

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# product-profunctors [![Hackage version](https://img.shields.io/hackage/v/product-profunctors.svg?label=Hackage)](https://hackage.haskell.org/package/product-profunctors) [![Build status](https://img.shields.io/github/workflow/status/tomjaguarpaw/product-profunctors/ci/master.svg)](https://github.com/tomjaguarpaw/product-profunctors/actions)
+# product-profunctors [![Hackage version](https://img.shields.io/hackage/v/product-profunctors.svg?label=Hackage)](https://hackage.haskell.org/package/product-profunctors) [![Build status](https://img.shields.io/github/actions/workflow/status/tomjaguarpaw/product-profunctors/ci.yml?branch=master)](https://github.com/tomjaguarpaw/product-profunctors/actions)
 
 ## Backup maintainers
 


### PR DESCRIPTION
This unbreaks the CI badge shown in the readme both on github and on hackage

See https://github.com/badges/shields/issues/8671 for details